### PR TITLE
Make Aurora-from-snapshot logical id independent of snapshot identifier

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 
 # CHANGELOG
 
+## 1.2.3
+
+- Fix a deployment failure when restoring the database from a different snapshot (`Cannot update export ... as it is in use by ...-Backend`). The database cluster's volatile attributes (secret, read endpoint, cluster resource id, security group) are now shared with the Backend and EC2Server stacks through SSM Parameter Store instead of CloudFormation cross-stack exports, so replacing the cluster (which happens whenever `db.dbSnapshotId` changes) no longer conflicts with in-use exports.
+- The `ServerlessAuroraDatabaseFromSnapshot` construct's logical id no longer depends on the snapshot identifier.
+
 ## 1.2.2
 
 - Bug fixes regarding php and aws-sdk for REDCap versions 16. The included aws-sdk in REDCap is now modified from the default instalation from compose and RDS library is not present. The setup script will now match REDCap SDK version and install the same to avoid version mismatch issues.

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -2,6 +2,11 @@ JP | [EN](./CHANGELOG)
 
 # CHANGELOG
 
+## 1.2.3
+
+- 別のスナップショットからデータベースを復元する際のデプロイ失敗（`Cannot update export ... as it is in use by ...-Backend`）を修正しました。データベースクラスターの可変属性（シークレット、リードエンドポイント、クラスターリソースID、セキュリティグループ）は、CloudFormationのクロススタックエクスポートではなくSSMパラメータストアを介してBackendおよびEC2Serverスタックと共有されるようになりました。これにより、（`db.dbSnapshotId` の変更時に発生する）クラスターの置き換えが、使用中のエクスポートと競合しなくなりました。
+- `ServerlessAuroraDatabaseFromSnapshot` コンストラクトの論理ID（Logical ID）がスナップショット識別子に依存しなくなりました。
+
 ## 1.2.2
 
 - REDCapバージョン16に関するphpとaws-sdkのバグ修正。REDCapに含まれるaws-sdkは、composeからのデフォルトインストールから変更されており、RDSライブラリが存在しません。セットアップスクリプトは、バージョン不一致の問題を回避するために、REDCap SDKバージョンと一致させて同じものをインストールするようになりました。

--- a/prototyping/constructs/AuroraServerlessV2.ts
+++ b/prototyping/constructs/AuroraServerlessV2.ts
@@ -4,7 +4,6 @@
  *  Licensed under the Amazon Software License  http://aws.amazon.com/asl/
  */
 
-import { createHash } from 'node:crypto';
 import { type aws_ec2, aws_iam, aws_rds, Duration, type RemovalPolicy, Stack } from 'aws-cdk-lib';
 import type { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -151,7 +150,7 @@ export class AuroraServerlessV2 extends Construct {
 
       this.aurora = new aws_rds.DatabaseClusterFromSnapshot(
         this,
-        `ServerlessAuroraDatabaseFromSnapshot-${createHash('sha1').update(props.snapshotIdentifier).digest('hex')}`,
+        'ServerlessAuroraDatabaseFromSnapshot',
         databaseSnapshotProps,
       );
 

--- a/prototyping/constructs/DatabaseConnection.ts
+++ b/prototyping/constructs/DatabaseConnection.ts
@@ -22,6 +22,7 @@ export class DatabaseConnection {
   public readonly securityGroup: ISecurityGroup;
 
   private readonly scope: Construct;
+  private readonly clusterResourceId: string;
 
   constructor(scope: Construct, stage: string) {
     this.scope = scope;
@@ -30,6 +31,10 @@ export class DatabaseConnection {
     this.secretArn = aws_ssm.StringParameter.valueForStringParameter(scope, names.secretArn);
     this.secretName = aws_ssm.StringParameter.valueForStringParameter(scope, names.secretName);
     this.readEndpoint = aws_ssm.StringParameter.valueForStringParameter(scope, names.readEndpoint);
+    this.clusterResourceId = aws_ssm.StringParameter.valueForStringParameter(
+      scope,
+      names.clusterResourceId,
+    );
 
     this.secret = aws_secretsmanager.Secret.fromSecretCompleteArn(
       scope,
@@ -45,13 +50,18 @@ export class DatabaseConnection {
     );
   }
 
+  /**
+   * Grant `rds-db:connect`. The cluster resource id is resolved from SSM, so the
+   * grant is scoped to the current cluster only (not other stages) and still
+   * survives cluster replacement (the SSM value updates on the next deploy).
+   */
   public grantConnect(grantee: IGrantable, dbUser: string): void {
     const stack = Stack.of(this.scope);
     const resourceArn = Arn.format(
       {
         service: 'rds-db',
         resource: 'dbuser',
-        resourceName: `*/${dbUser}`,
+        resourceName: `${this.clusterResourceId}/${dbUser}`,
         arnFormat: ArnFormat.COLON_RESOURCE_NAME,
       },
       stack,

--- a/prototyping/constructs/DatabaseConnection.ts
+++ b/prototyping/constructs/DatabaseConnection.ts
@@ -12,16 +12,7 @@ import type { Construct } from 'constructs';
 import { dbParameterNames } from '../dbSharedParameters';
 
 /**
- * Decoupled view of the database cluster for consuming stacks (Backend, EC2Server).
- *
- * Instead of importing the live cluster's volatile attributes through
- * CloudFormation cross-stack exports (which prevents replacing the cluster while
- * those exports are in use), the consuming stacks resolve the values from SSM
- * Parameter Store by their stable, stage-based names at deploy time.
- *
- * IAM grants are built from the resolved values (a reconstructed secret) and from
- * a stable `rds-db:connect` resource ARN scoped by database user, so they no
- * longer depend on the cluster's resource id and survive cluster replacement.
+ * Reads the DB cluster's volatile attributes from SSM
  */
 export class DatabaseConnection {
   public readonly secret: ISecret;
@@ -36,9 +27,6 @@ export class DatabaseConnection {
     this.scope = scope;
     const names = dbParameterNames(stage);
 
-    // Deploy-time dynamic references ({{resolve:ssm:...}}). These resolve to the
-    // current parameter value when the stack is deployed, so a cluster
-    // replacement (which updates the value in the Database stack) is picked up.
     this.secretArn = aws_ssm.StringParameter.valueForStringParameter(scope, names.secretArn);
     this.secretName = aws_ssm.StringParameter.valueForStringParameter(scope, names.secretName);
     this.readEndpoint = aws_ssm.StringParameter.valueForStringParameter(scope, names.readEndpoint);
@@ -57,13 +45,6 @@ export class DatabaseConnection {
     );
   }
 
-  /**
-   * Grant `rds-db:connect` for the given database user.
-   *
-   * The resource ARN uses a wildcard for the cluster resource id
-   * (`dbuser:*​/{dbUser}`) so the grant does not depend on the cluster's
-   * `clusterResourceIdentifier`, which changes when the cluster is replaced.
-   */
   public grantConnect(grantee: IGrantable, dbUser: string): void {
     const stack = Stack.of(this.scope);
     const resourceArn = Arn.format(
@@ -84,7 +65,6 @@ export class DatabaseConnection {
     );
   }
 
-  /** Grant read access to the database credentials secret. */
   public grantSecretRead(grantee: IGrantable | IRole): void {
     this.secret.grantRead(grantee);
   }

--- a/prototyping/constructs/DatabaseConnection.ts
+++ b/prototyping/constructs/DatabaseConnection.ts
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
+ *  Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+ */
+
+import { Arn, ArnFormat, aws_ec2, aws_iam, aws_secretsmanager, aws_ssm, Stack } from 'aws-cdk-lib';
+import type { ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
+import type { IGrantable, IRole } from 'aws-cdk-lib/aws-iam';
+import type { ISecret } from 'aws-cdk-lib/aws-secretsmanager';
+import type { Construct } from 'constructs';
+import { dbParameterNames } from '../dbSharedParameters';
+
+/**
+ * Decoupled view of the database cluster for consuming stacks (Backend, EC2Server).
+ *
+ * Instead of importing the live cluster's volatile attributes through
+ * CloudFormation cross-stack exports (which prevents replacing the cluster while
+ * those exports are in use), the consuming stacks resolve the values from SSM
+ * Parameter Store by their stable, stage-based names at deploy time.
+ *
+ * IAM grants are built from the resolved values (a reconstructed secret) and from
+ * a stable `rds-db:connect` resource ARN scoped by database user, so they no
+ * longer depend on the cluster's resource id and survive cluster replacement.
+ */
+export class DatabaseConnection {
+  public readonly secret: ISecret;
+  public readonly secretArn: string;
+  public readonly secretName: string;
+  public readonly readEndpoint: string;
+  public readonly securityGroup: ISecurityGroup;
+
+  private readonly scope: Construct;
+
+  constructor(scope: Construct, stage: string) {
+    this.scope = scope;
+    const names = dbParameterNames(stage);
+
+    // Deploy-time dynamic references ({{resolve:ssm:...}}). These resolve to the
+    // current parameter value when the stack is deployed, so a cluster
+    // replacement (which updates the value in the Database stack) is picked up.
+    this.secretArn = aws_ssm.StringParameter.valueForStringParameter(scope, names.secretArn);
+    this.secretName = aws_ssm.StringParameter.valueForStringParameter(scope, names.secretName);
+    this.readEndpoint = aws_ssm.StringParameter.valueForStringParameter(scope, names.readEndpoint);
+
+    this.secret = aws_secretsmanager.Secret.fromSecretCompleteArn(
+      scope,
+      'ImportedDbSecret',
+      this.secretArn,
+    );
+
+    this.securityGroup = aws_ec2.SecurityGroup.fromSecurityGroupId(
+      scope,
+      'ImportedDbSecurityGroup',
+      aws_ssm.StringParameter.valueForStringParameter(scope, names.securityGroupId),
+      { mutable: true },
+    );
+  }
+
+  /**
+   * Grant `rds-db:connect` for the given database user.
+   *
+   * The resource ARN uses a wildcard for the cluster resource id
+   * (`dbuser:*​/{dbUser}`) so the grant does not depend on the cluster's
+   * `clusterResourceIdentifier`, which changes when the cluster is replaced.
+   */
+  public grantConnect(grantee: IGrantable, dbUser: string): void {
+    const stack = Stack.of(this.scope);
+    const resourceArn = Arn.format(
+      {
+        service: 'rds-db',
+        resource: 'dbuser',
+        resourceName: `*/${dbUser}`,
+        arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+      },
+      stack,
+    );
+
+    grantee.grantPrincipal.addToPrincipalPolicy(
+      new aws_iam.PolicyStatement({
+        actions: ['rds-db:connect'],
+        resources: [resourceArn],
+      }),
+    );
+  }
+
+  /** Grant read access to the database credentials secret. */
+  public grantSecretRead(grantee: IGrantable | IRole): void {
+    this.secret.grantRead(grantee);
+  }
+}

--- a/prototyping/constructs/EcsFargate.ts
+++ b/prototyping/constructs/EcsFargate.ts
@@ -21,7 +21,6 @@ import {
 import { Rule } from 'aws-cdk-lib/aws-events';
 import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
-import type { DatabaseCluster } from 'aws-cdk-lib/aws-rds';
 import { ARecord, type IPublicHostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { LoadBalancerTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { DefinitionBody, LogLevel, StateMachine } from 'aws-cdk-lib/aws-stepfunctions';
@@ -37,6 +36,7 @@ import {
   type Stack,
 } from 'sst/constructs';
 import { bucketProps } from '../overrides/BucketProps';
+import type { DatabaseConnection } from './DatabaseConnection';
 
 export interface EcsFargateCertificate {
   fromArn?: string;
@@ -66,7 +66,7 @@ export interface EcsFargateProps {
   domain?: string;
   subdomain?: string;
   customDomain?: string | ServiceDomainProps | undefined;
-  databaseCluster: DatabaseCluster;
+  databaseCluster: DatabaseConnection;
   certificate?: EcsFargateCertificate;
   containerInsights?: boolean;
   publicHostedZone?: IPublicHostedZone;
@@ -117,15 +117,7 @@ export class EcsFargate extends Construct {
 
     this.ecsSg = new SecurityGroup(this, `redcap-ecs-service`, { vpc: props.network.vpc });
 
-    const sg = props.databaseCluster.connections.securityGroups;
-    const auroraSG = SecurityGroup.fromSecurityGroupId(
-      this,
-      'aurora-security-id',
-      sg[0].securityGroupId,
-      {
-        mutable: true,
-      },
-    );
+    const auroraSG = props.databaseCluster.securityGroup;
     auroraSG.addIngressRule(this.ecsSg, Port.tcp(3306));
 
     const albSg = new SecurityGroup(this, 'alb-sg', {

--- a/prototyping/dbSharedParameters.ts
+++ b/prototyping/dbSharedParameters.ts
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
+ *  Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+ */
+
+/**
+ * Well-known SSM parameter names used to share volatile database cluster
+ * attributes between the Database stack (producer) and the Backend / EC2Server
+ * stacks (consumers).
+ *
+ * These values (secret ARN/name, read endpoint, cluster resource id) change
+ * whenever the Aurora cluster is replaced (for example when restoring from a
+ * different snapshot). Passing them via CloudFormation cross-stack exports made
+ * such a replacement fail with "cannot update export ... as it is in use by ...".
+ *
+ * Reading them by a stable SSM parameter name instead avoids the CloudFormation
+ * export/import lock: the Database stack updates the parameter value in place and
+ * the consuming stacks resolve the current value at deploy time via a dynamic
+ * reference, so a cluster replacement is no longer blocked.
+ *
+ * The parameter name only depends on the stage (a stable value), never on the
+ * cluster's logical id or resource id.
+ */
+export function dbParameterNames(stage: string) {
+  const base = `/${stage}/redcap/db`;
+  return {
+    secretArn: `${base}/secretArn`,
+    secretName: `${base}/secretName`,
+    readEndpoint: `${base}/readEndpoint`,
+    clusterResourceId: `${base}/clusterResourceId`,
+    securityGroupId: `${base}/securityGroupId`,
+  };
+}

--- a/prototyping/dbSharedParameters.ts
+++ b/prototyping/dbSharedParameters.ts
@@ -4,24 +4,6 @@
  *  Licensed under the Amazon Software License  http://aws.amazon.com/asl/
  */
 
-/**
- * Well-known SSM parameter names used to share volatile database cluster
- * attributes between the Database stack (producer) and the Backend / EC2Server
- * stacks (consumers).
- *
- * These values (secret ARN/name, read endpoint, cluster resource id) change
- * whenever the Aurora cluster is replaced (for example when restoring from a
- * different snapshot). Passing them via CloudFormation cross-stack exports made
- * such a replacement fail with "cannot update export ... as it is in use by ...".
- *
- * Reading them by a stable SSM parameter name instead avoids the CloudFormation
- * export/import lock: the Database stack updates the parameter value in place and
- * the consuming stacks resolve the current value at deploy time via a dynamic
- * reference, so a cluster replacement is no longer blocked.
- *
- * The parameter name only depends on the stage (a stable value), never on the
- * cluster's logical id or resource id.
- */
 export function dbParameterNames(stage: string) {
   const base = `/${stage}/redcap/db`;
   return {

--- a/stacks/Backend.ts
+++ b/stacks/Backend.ts
@@ -36,11 +36,8 @@ export function Backend({ stack, app }: StackContext) {
   const { dbAllowedSg } = use(Database);
   const repository = use(BuildImage);
 
-  // Resolve the database cluster's volatile attributes (secret, read endpoint,
-  // etc.) from SSM Parameter Store by their stable names, rather than importing
-  // them through CloudFormation cross-stack exports. This lets the Database stack
-  // replace the cluster (e.g. when restoring from a different snapshot) without
-  // hitting "cannot update export ... as it is in use by dev-REDCap-Backend".
+  // Resolve DB attributes from SSM (see DatabaseConnection) instead of
+  // cross-stack exports, so the cluster can be replaced without breaking deploys.
   const dbConnection = new DatabaseConnection(stack, stack.stage);
 
   // Config

--- a/stacks/Backend.ts
+++ b/stacks/Backend.ts
@@ -11,6 +11,7 @@ import { assign, get, isEmpty, random } from 'lodash';
 import { Bucket, type StackContext, use } from 'sst/constructs';
 // Nag suppressions
 import Suppressions from '../prototyping/cdkNag/Suppressions';
+import { DatabaseConnection } from '../prototyping/constructs/DatabaseConnection';
 // Construct and other assets
 import { RedCapAwsAccessUser } from '../prototyping/constructs/RedCapAwsAccessUser';
 import {
@@ -32,12 +33,15 @@ const { createHmac } = await import('node:crypto');
 
 export function Backend({ stack, app }: StackContext) {
   const { networkVpc } = use(Network);
-  const { dbAllowedSg, auroraClusterV2 } = use(Database);
+  const { dbAllowedSg } = use(Database);
   const repository = use(BuildImage);
 
-  if (!auroraClusterV2.aurora.secret) {
-    throw new Error('No database secret found');
-  }
+  // Resolve the database cluster's volatile attributes (secret, read endpoint,
+  // etc.) from SSM Parameter Store by their stable names, rather than importing
+  // them through CloudFormation cross-stack exports. This lets the Database stack
+  // replace the cluster (e.g. when restoring from a different snapshot) without
+  // hitting "cannot update export ... as it is in use by dev-REDCap-Backend".
+  const dbConnection = new DatabaseConnection(stack, stack.stage);
 
   // Config
   const domain = get(stage, [stack.stage, 'domain']);
@@ -149,30 +153,28 @@ export function Backend({ stack, app }: StackContext) {
   const environmentVariables = {
     S3_BUCKET: redcapApplicationBucket.bucketName,
     USE_IAM_DB_AUTH: 'true',
-    DB_SECRET_NAME: auroraClusterV2.aurora.secret.secretName,
+    DB_SECRET_NAME: dbConnection.secretName,
     SMTP_EMAIL: email,
-    DB_SECRET_ID: auroraClusterV2.aurora.secret.secretArn,
+    DB_SECRET_ID: dbConnection.secretArn,
     DB_SALT_SECRET_ID: dbSalt.secretArn,
     SES_CREDENTIALS_SECRET_ID: ses.sesUserCredentials.secretArn,
     S3_SECRET_ID: redCapS3AccessUser.secret.secretArn,
     PHP_TIMEZONE: phpTimezone || 'UTC',
   };
 
-  if (auroraClusterV2?.aurora.clusterReadEndpoint.hostname) {
-    assign(environmentVariables, {
-      READ_REPLICA_HOSTNAME: auroraClusterV2.aurora.clusterReadEndpoint.hostname,
-    });
-  }
+  assign(environmentVariables, {
+    READ_REPLICA_HOSTNAME: dbConnection.readEndpoint,
+  });
 
   const service = new RedcapService(stack, app, {
-    databaseCluster: auroraClusterV2.aurora,
+    dbConnection,
     domain,
     subdomain,
     publicHostedZone,
     waf,
     secrets: {
       dbSalt,
-      dbSecret: auroraClusterV2.aurora.secret,
+      dbSecret: dbConnection.secret,
       redCapS3AccessUser,
       ses,
     },

--- a/stacks/Backend/RedCapService.ts
+++ b/stacks/Backend/RedCapService.ts
@@ -6,12 +6,12 @@ import type { Repository } from 'aws-cdk-lib/aws-ecr';
 import { type Connection, HttpMethod } from 'aws-cdk-lib/aws-events';
 import { ApiDestination } from 'aws-cdk-lib/aws-events-targets';
 import type { IGrantable } from 'aws-cdk-lib/aws-iam';
-import type { DatabaseCluster } from 'aws-cdk-lib/aws-rds';
 import type { IPublicHostedZone } from 'aws-cdk-lib/aws-route53';
 import type { ISecret } from 'aws-cdk-lib/aws-secretsmanager';
 import { get, isNumber } from 'lodash';
 import type { App, ServiceProps, Stack } from 'sst/constructs';
 import { AppRunner } from '../../prototyping/constructs/AppRunner';
+import type { DatabaseConnection } from '../../prototyping/constructs/DatabaseConnection';
 import { EcsFargate } from '../../prototyping/constructs/EcsFargate';
 import type { RedCapAwsAccessUser } from '../../prototyping/constructs/RedCapAwsAccessUser';
 import type { SimpleEmailService } from '../../prototyping/constructs/SimpleEmailService';
@@ -43,7 +43,7 @@ export class RedcapService {
         ses: SimpleEmailService;
         redCapS3AccessUser: RedCapAwsAccessUser;
       };
-      databaseCluster: DatabaseCluster;
+      dbConnection: DatabaseConnection;
       vpc: Vpc;
       servicePort: number;
       repository: Repository;
@@ -64,7 +64,7 @@ export class RedcapService {
     this.common.secrets.dbSalt.grantRead(grantee);
     this.common.secrets.ses.sesUserCredentials.grantRead(grantee);
     this.common.secrets.redCapS3AccessUser.secret.grantRead(grantee);
-    this.common.databaseCluster.grantConnect(grantee, 'redcap_user');
+    this.common.dbConnection.grantConnect(grantee, 'redcap_user');
   }
 
   private associateWaf(resourceArn: string, serviceType: string) {
@@ -149,7 +149,7 @@ export class RedcapService {
       domain: this.common.domain,
       subdomain: this.common.subdomain,
       environmentVariables: this.common.environmentVariables,
-      databaseCluster: this.common.databaseCluster,
+      databaseCluster: this.common.dbConnection,
       containerInsights: true,
       publicHostedZone: this.common.publicHostedZone,
       certificate: {

--- a/stacks/Database.ts
+++ b/stacks/Database.ts
@@ -77,11 +77,9 @@ export function Database({ stack, app }: StackContext) {
     preferredMaintenanceWindow,
   });
 
-  // Publish the volatile cluster attributes to SSM Parameter Store instead of
-  // sharing them through CloudFormation cross-stack exports. The parameter names
-  // are stable (stage-based), so replacing the cluster (e.g. restoring a different
-  // snapshot) only changes the parameter *value* and never triggers the
-  // "cannot update export ... as it is in use" failure between Database and Backend.
+  // Publish volatile cluster attributes to SSM instead of CloudFormation exports,
+  // so replacing the cluster (e.g. snapshot restore) doesn't hit
+  // "cannot update export ... as it is in use". See dbSharedParameters.
   const dbParams = dbParameterNames(stack.stage);
 
   if (auroraClusterV2.aurora.secret) {

--- a/stacks/Database.ts
+++ b/stacks/Database.ts
@@ -4,7 +4,7 @@
  *  Licensed under the Amazon Software License  http://aws.amazon.com/asl/
  */
 
-import { aws_ec2, Duration } from 'aws-cdk-lib';
+import { aws_ec2, aws_ssm, Duration } from 'aws-cdk-lib';
 import { AuroraMysqlEngineVersion } from 'aws-cdk-lib/aws-rds';
 import { get } from 'lodash';
 import moment from 'moment';
@@ -12,6 +12,7 @@ import { type StackContext, use } from 'sst/constructs';
 import type { RedCapConfig } from '../prototyping';
 import Suppressions from '../prototyping/cdkNag/Suppressions';
 import { AuroraServerlessV2 } from '../prototyping/constructs/AuroraServerlessV2';
+import { dbParameterNames } from '../prototyping/dbSharedParameters';
 import * as stage from '../stages';
 import { Network } from './Network';
 
@@ -56,7 +57,8 @@ export function Database({ stack, app }: StackContext) {
 
   const auroraClusterV2 = new AuroraServerlessV2(stack, 'RDSV2', {
     engine: 'mysql8.0',
-    engineVersion: dbConfig?.engineVersion ?? AuroraMysqlEngineVersion.of('8.0.mysql_aurora.3.10.3', '8.0'),
+    engineVersion:
+      dbConfig?.engineVersion ?? AuroraMysqlEngineVersion.of('8.0.mysql_aurora.3.10.3', '8.0'),
     defaultDatabaseName: 'redcap',
     dbUserName: 'dbadmin',
     vpc: networkVpc.vpc,
@@ -75,8 +77,38 @@ export function Database({ stack, app }: StackContext) {
     preferredMaintenanceWindow,
   });
 
-  stack.exportValue(auroraClusterV2.aurora.clusterResourceIdentifier);
-  stack.exportValue(auroraClusterV2.aurora.connections.securityGroups[0].securityGroupId);
+  // Publish the volatile cluster attributes to SSM Parameter Store instead of
+  // sharing them through CloudFormation cross-stack exports. The parameter names
+  // are stable (stage-based), so replacing the cluster (e.g. restoring a different
+  // snapshot) only changes the parameter *value* and never triggers the
+  // "cannot update export ... as it is in use" failure between Database and Backend.
+  const dbParams = dbParameterNames(stack.stage);
+
+  if (auroraClusterV2.aurora.secret) {
+    new aws_ssm.StringParameter(stack, 'DbSecretArnParam', {
+      parameterName: dbParams.secretArn,
+      stringValue: auroraClusterV2.aurora.secret.secretArn,
+    });
+    new aws_ssm.StringParameter(stack, 'DbSecretNameParam', {
+      parameterName: dbParams.secretName,
+      stringValue: auroraClusterV2.aurora.secret.secretName,
+    });
+  }
+
+  new aws_ssm.StringParameter(stack, 'DbReadEndpointParam', {
+    parameterName: dbParams.readEndpoint,
+    stringValue: auroraClusterV2.aurora.clusterReadEndpoint.hostname,
+  });
+
+  new aws_ssm.StringParameter(stack, 'DbClusterResourceIdParam', {
+    parameterName: dbParams.clusterResourceId,
+    stringValue: auroraClusterV2.aurora.clusterResourceIdentifier,
+  });
+
+  new aws_ssm.StringParameter(stack, 'DbSecurityGroupIdParam', {
+    parameterName: dbParams.securityGroupId,
+    stringValue: auroraClusterV2.aurora.connections.securityGroups[0].securityGroupId,
+  });
 
   auroraClusterV2?.aurora.connections.allowDefaultPortFrom(dbAllowedSg);
   Suppressions.RDSV2Suppressions(auroraClusterV2);

--- a/stacks/EC2Server.ts
+++ b/stacks/EC2Server.ts
@@ -61,9 +61,7 @@ export function EC2Server({ stack, app }: StackContext) {
   const { dbSalt, s3UserCredentials, sesUserCredentials, environmentVariables } = use(Backend);
   const { dbAllowedSg } = use(Database);
 
-  // Resolve the database cluster's volatile attributes from SSM (by stable name)
-  // instead of importing them via CloudFormation exports, so the cluster can be
-  // replaced without breaking this stack. See DatabaseConnection for details.
+  // Resolve DB attributes from SSM
   const dbConnection = new DatabaseConnection(stack, stack.stage);
 
   const userData = UserData.forLinux({ shebang: '#!/bin/bash' });

--- a/stacks/EC2Server.ts
+++ b/stacks/EC2Server.ts
@@ -25,6 +25,7 @@ import { get } from 'lodash';
 import { type StackContext, Function as sstFunction, use } from 'sst/constructs';
 
 import Suppressions from '../prototyping/cdkNag/Suppressions';
+import { DatabaseConnection } from '../prototyping/constructs/DatabaseConnection';
 import * as stage from '../stages';
 import { Backend } from './Backend';
 import { BuildImage } from './BuildImage';
@@ -58,7 +59,12 @@ export function EC2Server({ stack, app }: StackContext) {
   const repository = use(BuildImage);
   const { networkVpc } = use(Network);
   const { dbSalt, s3UserCredentials, sesUserCredentials, environmentVariables } = use(Backend);
-  const { dbAllowedSg, auroraClusterV2 } = use(Database);
+  const { dbAllowedSg } = use(Database);
+
+  // Resolve the database cluster's volatile attributes from SSM (by stable name)
+  // instead of importing them via CloudFormation exports, so the cluster can be
+  // replaced without breaking this stack. See DatabaseConnection for details.
+  const dbConnection = new DatabaseConnection(stack, stack.stage);
 
   const userData = UserData.forLinux({ shebang: '#!/bin/bash' });
 
@@ -113,14 +119,14 @@ export function EC2Server({ stack, app }: StackContext) {
   });
 
   // Allow secrets read for EC2 instance
-  auroraClusterV2.aurora.secret?.grantRead(ec2ServerInstance.role);
+  dbConnection.grantSecretRead(ec2ServerInstance.role);
   dbSalt.grantRead(ec2ServerInstance.role);
   s3UserCredentials.grantRead(ec2ServerInstance.role);
   sesUserCredentials.grantRead(ec2ServerInstance.role);
   repository.grantPull(ec2ServerInstance.role);
 
   // Allow RDS IAM connect
-  auroraClusterV2.aurora.grantConnect(ec2ServerInstance.role, 'redcap_user');
+  dbConnection.grantConnect(ec2ServerInstance.role, 'redcap_user');
 
   const wait = new Wait(stack, `wait`, {
     time: WaitTime.duration(ec2StackDuration),


### PR DESCRIPTION
Closes #115 

## Summary

Fixes the deployment restoring the database from a snapshot with a *different* identifier fails due to a cross-stack dependency error between the Database and Backend stacks.

## Root cause

In `prototyping/constructs/AuroraServerlessV2.ts`, the `DatabaseClusterFromSnapshot` construct id was derived from a SHA-1 hash of the snapshot identifier:

```ts
`ServerlessAuroraDatabaseFromSnapshot-${createHash('sha1').update(props.snapshotIdentifier).digest('hex')}`
```

## Change

Use a stable, fixed construct id (`ServerlessAuroraDatabaseFromSnapshot`) that does not depend on the snapshot identifier, so a snapshot change is processed as an in-place update instead of a replace-and-recreate. The now-unused `createHash` import is removed.

